### PR TITLE
Move the buffer to a local variable to avoid corruption when ZipUtils…

### DIFF
--- a/src/me/iarekylew00t/utils/ZipUtils.java
+++ b/src/me/iarekylew00t/utils/ZipUtils.java
@@ -8,17 +8,17 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 public final class ZipUtils {
-	public static final byte[] BUFFER = new byte[8192];
-
 	public static final File zipFile(File src, File dest) throws IOException {
+		byte[] buffer = new byte[8192];
+
 		ZipOutputStream zip = new ZipOutputStream(new FileOutputStream(dest));
 		ZipEntry entry = new ZipEntry(src.getName());
 		zip.putNextEntry(entry);
 		
 		FileInputStream in = new FileInputStream(src);
 		int len;
-		while ((len = in.read(BUFFER)) > 0) {
-			zip.write(BUFFER, 0, len);
+		while ((len = in.read(buffer)) > 0) {
+			zip.write(buffer, 0, len);
 		}
 		
 		in.close();


### PR DESCRIPTION
….zipFile() is called from multiple threads